### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClosedCube_TCA9548A
-version=0.1b
+version=0.1.0-b
 author=ClosedCube
 maintainer=ClosedCube GitHub Support <github@closedcube.com>
 sentence=Arduino library for ClosedCube TCA9548A 8-Channel I2C Switch with 1.8 (Buck) and 5V (Boost) Breakout Board


### PR DESCRIPTION
The previous version value caused the Arduino IDE to display warnings:
```
Invalid version found: 0.1b
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Installing a library with an invalid version causes Arduino IDE 1.8.6 to no longer start.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format